### PR TITLE
create new GitHub Action to test submodule pointers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,4 +11,5 @@ jobs:
         with:
           submodules: recursive
           lfs: false
+          # NOTE: this token is attached to my (@zacharyburnettNOAA) account because I have permission to clone the `adcirc-cg` repo which is private; perhaps in the future we can use the token from a dummy account, and / or an SSH key? The token is currently stored in the repository Secrets at https://github.com/noaa-ocs-modeling/ADC-WW3-NWM-NEMS/settings/secrets/actions
           token: ${{ secrets.PULL_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,3 +10,5 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+          lfs: false
+          token: ${{ secrets.PULL_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,12 @@
+name: tests
+
+on: [push]
+
+jobs:
+  checkout:
+    name: Checkout repository with `--recursive` to validate submodule pointers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive


### PR DESCRIPTION
this GitHub Workflow triggers on every push, and will do 1 thing right now: clone the repository at the pushed commit

if there are any problems with cloning (i.e. the submodule pointers are wrong) then the test will fail and show a red X